### PR TITLE
ログインしているユーザーの情報を元に、家計簿一覧を表示するように変更

### DIFF
--- a/src/main/java/com/example/controller/kakeibo/KakeiboController.java
+++ b/src/main/java/com/example/controller/kakeibo/KakeiboController.java
@@ -21,7 +21,6 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 
-import com.example.domain.kakeibo.DeletedKakeibo;
 import com.example.domain.kakeibo.Kakeibo;
 import com.example.domain.user.User;
 import com.example.form.kakeibo.AddKakeiboForm;
@@ -145,29 +144,29 @@ public class KakeiboController {
 		return "redirect:/kakeibo/list";
 	}
 
-	/**
-	 * 家計簿を論理削除する
-	 *
-	 * @param id 家計簿id
-	 * @return
-	 */
-	@RequestMapping(value = "/delete", method = RequestMethod.POST)
-	public String delete(Integer id) {
-		DeletedKakeibo deletedKakeibo = new DeletedKakeibo();
-		Kakeibo kakeibo = new Kakeibo();
-
-		// 値をセット
-		deletedKakeibo.setKakeiboId(id);
-
-		// 削除フラグをtrueにする
-		kakeibo.setId(id);
-
-		// 論理削除の実行
-		kakeiboService.delete(deletedKakeibo);
-		kakeiboService.updateIsDelete(kakeibo);
-
-		return "redirect:/kakeibo/list";
-	}
+	//	/**
+	//	 * 家計簿を論理削除する
+	//	 *
+	//	 * @param id 家計簿id
+	//	 * @return
+	//	 */
+	//	@RequestMapping(value = "/delete", method = RequestMethod.POST)
+	//	public String delete(Integer id) {
+	//		DeletedKakeibo deletedKakeibo = new DeletedKakeibo();
+	//		Kakeibo kakeibo = new Kakeibo();
+	//
+	//		// 値をセット
+	//		deletedKakeibo.setKakeiboId(id);
+	//
+	//		// 削除フラグをtrueにする
+	//		kakeibo.setId(id);
+	//
+	//		// 論理削除の実行
+	//		kakeiboService.delete(deletedKakeibo);
+	//		kakeiboService.updateIsDelete(kakeibo);
+	//
+	//		return "redirect:/kakeibo/list";
+	//	}
 
 	/**
 	 * 日付を取得するためのメソッド

--- a/src/main/java/com/example/controller/kakeibo/KakeiboController.java
+++ b/src/main/java/com/example/controller/kakeibo/KakeiboController.java
@@ -5,6 +5,8 @@ import java.time.format.DateTimeFormatter;
 import java.util.List;
 import java.util.Map;
 
+import javax.servlet.http.HttpSession;
+
 import org.springframework.beans.BeanUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.format.annotation.DateTimeFormat;
@@ -21,6 +23,7 @@ import org.springframework.web.bind.annotation.RequestMethod;
 
 import com.example.domain.kakeibo.DeletedKakeibo;
 import com.example.domain.kakeibo.Kakeibo;
+import com.example.domain.user.User;
 import com.example.form.kakeibo.AddKakeiboForm;
 import com.example.form.kakeibo.EditKakeiboForm;
 import com.example.form.kakeibo.SearchKakeiboForm;
@@ -30,6 +33,9 @@ import com.example.service.user.LoginService;
 @Controller
 @RequestMapping("/kakeibo")
 public class KakeiboController {
+
+	@Autowired
+	HttpSession session;
 
 	@Autowired
 	KakeiboService kakeiboService;
@@ -55,7 +61,13 @@ public class KakeiboController {
 	 */
 	@GetMapping("/list")
 	public String getList(Model model) {
-		model.addAttribute("kakeiboList", kakeiboService.findKakeiboList());
+		// ログインチェックを追加
+		User user = (User) session.getAttribute("user");
+		if (user == null) {
+			return "redirect:/user/login";
+		}
+
+		model.addAttribute("kakeiboList", kakeiboService.findKakeiboList(user.getId()));
 		return "kakeibo/kakeiboList";
 	}
 

--- a/src/main/java/com/example/domain/kakeibo/Kakeibo.java
+++ b/src/main/java/com/example/domain/kakeibo/Kakeibo.java
@@ -3,25 +3,27 @@ package com.example.domain.kakeibo;
 import java.sql.Timestamp;
 import java.time.LocalDate;
 
+import com.example.domain.user.User;
+
 import lombok.Data;
 
 @Data
 public class Kakeibo {
 
 	/** 家計簿Id */
-	private long id;
+	private Long id;
 	/** ユーザーId */
-	private Integer userId;
+	private Long userId;
 	/** 決済日付 */
 	private LocalDate paymentDate;
 	/** 費目Id */
-	private Integer expenseItemId;
+	private Long expenseItemId;
 	/** 支出金額 */
 	private Integer expenditureAmount;
 	/** 収入金額 */
 	private Integer incomeAmount;
 	/** 決済Id */
-	private Integer settlementId;
+	private Long settlementId;
 	/** 利用店舗 */
 	private String usedStore;
 	/** 備考 */
@@ -34,5 +36,7 @@ public class Kakeibo {
 	private ExpenseItem expenseItem;
 	/** 決済 */
 	private Settlement settlement;
+	/** ユーザー */
+	private User user;
 
 }

--- a/src/main/java/com/example/domain/kakeibo/Kakeibo.java
+++ b/src/main/java/com/example/domain/kakeibo/Kakeibo.java
@@ -34,5 +34,5 @@ public class Kakeibo {
 	private ExpenseItem expenseItem;
 	/** 決済 */
 	private Settlement settlement;
-	
+
 }

--- a/src/main/java/com/example/repository/kakeibo/KakeiboMapper.java
+++ b/src/main/java/com/example/repository/kakeibo/KakeiboMapper.java
@@ -7,7 +7,6 @@ import org.apache.ibatis.annotations.Mapper;
 import com.example.domain.kakeibo.DeletedKakeibo;
 import com.example.domain.kakeibo.Kakeibo;
 import com.example.domain.kakeibo.MonthlyBalanceCalculationResult;
-import com.example.domain.kakeibo.TotalByIncomeAndExpenditureBreakdown;
 
 @Mapper
 public interface KakeiboMapper {
@@ -17,7 +16,7 @@ public interface KakeiboMapper {
 	 * 
 	 * @return 検索結果
 	 */
-	List<Kakeibo> findAll();
+	List<Kakeibo> findAll(Long userId);
 
 	/**
 	 * 家計簿idから家計簿情報を取得

--- a/src/main/java/com/example/service/kakeibo/KakeiboService.java
+++ b/src/main/java/com/example/service/kakeibo/KakeiboService.java
@@ -2,22 +2,19 @@ package com.example.service.kakeibo;
 
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.Map;
-import java.util.stream.Collectors;
-import java.util.stream.IntStream;
-import java.util.ArrayList;
-import java.util.HashMap;
 import com.example.domain.kakeibo.DeletedKakeibo;
 import com.example.domain.kakeibo.Kakeibo;
 import com.example.domain.kakeibo.MonthlyBalanceCalculationResult;
-import com.example.domain.kakeibo.TotalByIncomeAndExpenditureBreakdown;
 import com.example.repository.kakeibo.KakeiboMapper;
 
 import lombok.extern.slf4j.Slf4j;
@@ -35,8 +32,8 @@ public class KakeiboService {
 	 * 
 	 * @return 検索結果
 	 */
-	public List<Kakeibo> findKakeiboList() {
-		return kakeiboMapper.findAll();
+	public List<Kakeibo> findKakeiboList(Long userId) {
+		return kakeiboMapper.findAll(userId);
 	}
 
 	/**
@@ -155,7 +152,7 @@ public class KakeiboService {
 		if (kakeiboItemList == null || kakeiboItemList.size() == 0) {
 			return null;
 		}
-		
+
 		return kakeiboItemList;
 	}
 
@@ -252,7 +249,7 @@ public class KakeiboService {
 	 * 
 	 */
 	public Map<String, Double> calculatePercentage(Map<String, Double> doubleMap) {
-		if(doubleMap.isEmpty()) {
+		if (doubleMap.isEmpty()) {
 			return null;
 		}
 

--- a/src/main/resources/com/example/repository/kakeibo/kakeiboMapper.xml
+++ b/src/main/resources/com/example/repository/kakeibo/kakeiboMapper.xml
@@ -29,6 +29,8 @@
 			settlement as s
 		ON
 			k.settlement_id = s.id
+		WHERE
+			k.user_id = #{userId}
 		ORDER BY
 			k.payment_date DESC,
 			k.update_at DESC;

--- a/src/test/java/com/example/controller/kakeibo/KakeiboControllerKakeiboByYeayAndMonthTest.java
+++ b/src/test/java/com/example/controller/kakeibo/KakeiboControllerKakeiboByYeayAndMonthTest.java
@@ -1,13 +1,10 @@
 package com.example.controller.kakeibo;
 
 import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.when;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.model;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.view;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 import java.time.LocalDate;
 import java.util.ArrayList;
@@ -34,11 +31,11 @@ import com.example.service.kakeibo.KakeiboService;
 @SpringBootTest
 @AutoConfigureMockMvc
 class KakeiboControllerKakeiboByYeayAndMonthTest {
-	
+
 	List<Kakeibo> kakeiboList;
 	Kakeibo kakeibo;
 	MonthlyBalanceCalculationResult calc;
-	
+
 	@BeforeAll
 	static void setUpBeforeClass() throws Exception {
 		// テスト準備(2022年11月のデータをセット)
@@ -46,7 +43,7 @@ class KakeiboControllerKakeiboByYeayAndMonthTest {
 		Kakeibo kakeibo = new Kakeibo();
 		kakeibo.setId(1L);
 		kakeibo.setPaymentDate(LocalDate.parse("2022-11-04"));
-		kakeibo.setExpenseItemId(2);
+		kakeibo.setExpenseItemId(2L);
 		kakeibo.setExpenditureAmount(5000);
 		kakeibo.setIncomeAmount(0);
 		ExpenseItem expenseItem = new ExpenseItem();
@@ -58,20 +55,20 @@ class KakeiboControllerKakeiboByYeayAndMonthTest {
 		settlement.setSettlementName("現金");
 		kakeibo.setSettlement(settlement);
 		kakeiboList.add(kakeibo);
-		
+
 		// 収支結果に値をセット
 		MonthlyBalanceCalculationResult calc = new MonthlyBalanceCalculationResult();
 		calc.setTotalIncomeAmount(kakeibo.getIncomeAmount());
 		calc.setTotalExpenditureAmount(kakeibo.getExpenditureAmount());
 		calc.setBalanceCalculationResult(kakeibo.getIncomeAmount() - kakeibo.getExpenditureAmount());
 	}
-	
+
 	@Autowired
 	private MockMvc mockMvc;
-	
+
 	@MockBean
 	private KakeiboService kakeiboService;
-	
+
 	/** getKakeiboByYearAndMonth(年別・月別集計結果を表示する画面(kakeiboByYearAndMonth.html)を表示)のテスト */
 
 	@Test
@@ -79,10 +76,10 @@ class KakeiboControllerKakeiboByYeayAndMonthTest {
 	void testGetKakeiboByYearAndMonth() throws Exception {
 		// 検証&実行
 		mockMvc.perform(get("/kakeibo/kakeiboByYearAndMonth"))
-		.andExpect(status().isOk())
-		.andExpect(view().name("kakeibo/kakeiboByYearAndMonth"));
+				.andExpect(status().isOk())
+				.andExpect(view().name("kakeibo/kakeiboByYearAndMonth"));
 	}
-	
+
 	/** postKakeiboByYearAndMonth(年別・月別集計結果処理)のテスト */
 	
 	// 異常系
@@ -104,9 +101,9 @@ class KakeiboControllerKakeiboByYeayAndMonthTest {
 		// 検証
 		assertEquals(modelAndView.getModel().get("message"), "ご入力頂いた年月のデータは存在しません（年の指定は必須です）");
 	}
-	
+
 	// 正常系
-	
+
 	@Test
 	@DisplayName("年月共に入力されている時、リストを返す")
 	void testYearAndMonthIsNotNull() throws Exception {
@@ -125,7 +122,7 @@ class KakeiboControllerKakeiboByYeayAndMonthTest {
 		// 検証
 		assertEquals(modelAndView.getModel().get("kakeiboList"), kakeiboList);
 	}
-	
+
 	@Test
 	@DisplayName("年のみ入力されている時のテスト")
 	void testMonthIsNull() throws Exception {
@@ -145,7 +142,7 @@ class KakeiboControllerKakeiboByYeayAndMonthTest {
 		// 検証
 		assertEquals(modelAndView.getModel().get("kakeiboList"), kakeiboList);
 	}
-	
+
 	@Test
 	@DisplayName("正常な値の時、収支計算結果を表示する")
 	void testMonthlyBalanceCalculationResult() throws Exception {
@@ -165,68 +162,68 @@ class KakeiboControllerKakeiboByYeayAndMonthTest {
 		// 検証
 		assertEquals(modelAndView.getModel().get("result"), calc);
 	}
-	
+
 	/** 入力値チェックに関する項目 */
-	
+
 	// 異常系
-	
+
 	@Test
 	@DisplayName("年を入力しなかった時、エラーとなる(入力値チェック)")
 	void testNull() throws Exception {
 		SearchKakeiboForm searchKakeiboForm = new SearchKakeiboForm();
 		searchKakeiboForm.setYear(null);
-		
+
 		// 検証&実行
 		mockMvc.perform(post("/kakeibo/kakeiboByYearAndMonth")
 				.flashAttr("searchKakeiboForm", searchKakeiboForm))
-		.andExpect(model().hasErrors())
-		.andExpect(model().attributeHasErrors("searchKakeiboForm"))
-		.andExpect(view().name("kakeibo/kakeiboByYearAndMonth"));
+				.andExpect(model().hasErrors())
+				.andExpect(model().attributeHasErrors("searchKakeiboForm"))
+				.andExpect(view().name("kakeibo/kakeiboByYearAndMonth"));
 	}
-	
+
 	@Test
 	@DisplayName("月のみ入力した時、エラーとなる(入力値チェック)")
 	void testYearIsNull() throws Exception {
 		SearchKakeiboForm searchKakeiboForm = new SearchKakeiboForm();
 		searchKakeiboForm.setMonth("11");
-		
+
 		// 検証&実行
 		mockMvc.perform(post("/kakeibo/kakeiboByYearAndMonth")
 				.flashAttr("searchKakeiboForm", searchKakeiboForm))
-		.andExpect(model().hasErrors())
-		.andExpect(model().attributeHasErrors("searchKakeiboForm"))
-		.andExpect(view().name("kakeibo/kakeiboByYearAndMonth"));
+				.andExpect(model().hasErrors())
+				.andExpect(model().attributeHasErrors("searchKakeiboForm"))
+				.andExpect(view().name("kakeibo/kakeiboByYearAndMonth"));
 	}
-	
+
 	// 正常系
-	
+
 	@Test
 	@DisplayName("年月共に入力した時、正常に表示される(入力値チェック)")
 	void testYearAndMonth() throws Exception {
 		SearchKakeiboForm searchKakeiboForm = new SearchKakeiboForm();
 		searchKakeiboForm.setYear("2022");
 		searchKakeiboForm.setMonth("11");
-		
+
 		// 検証&実行
 		mockMvc.perform(post("/kakeibo/kakeiboByYearAndMonth")
 				.flashAttr("searchKakeiboForm", searchKakeiboForm))
-		.andExpect(model().hasNoErrors())
-		.andExpect(model().attribute("searchKakeiboForm", searchKakeiboForm))
-		.andExpect(view().name("kakeibo/kakeiboByYearAndMonth"));
+				.andExpect(model().hasNoErrors())
+				.andExpect(model().attribute("searchKakeiboForm", searchKakeiboForm))
+				.andExpect(view().name("kakeibo/kakeiboByYearAndMonth"));
 	}
-	
+
 	@Test
 	@DisplayName("年のみ入力した時、正常に表示される(入力値チェック)")
 	void testYear() throws Exception {
 		SearchKakeiboForm searchKakeiboForm = new SearchKakeiboForm();
 		searchKakeiboForm.setYear("2022");
 		searchKakeiboForm.setMonth(null);
-		
+
 		// 検証&実行
 		mockMvc.perform(post("/kakeibo/kakeiboByYearAndMonth")
 				.flashAttr("searchKakeiboForm", searchKakeiboForm))
-		.andExpect(model().hasNoErrors())
-		.andExpect(model().attribute("searchKakeiboForm", searchKakeiboForm))
-		.andExpect(view().name("kakeibo/kakeiboByYearAndMonth"));
+				.andExpect(model().hasNoErrors())
+				.andExpect(model().attribute("searchKakeiboForm", searchKakeiboForm))
+				.andExpect(view().name("kakeibo/kakeiboByYearAndMonth"));
 	}
 }

--- a/src/test/java/com/example/controller/kakeibo/KakeiboControllerTest.java
+++ b/src/test/java/com/example/controller/kakeibo/KakeiboControllerTest.java
@@ -1,32 +1,23 @@
 package com.example.controller.kakeibo;
 
 import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.doReturn;
-import static org.mockito.Mockito.when;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.view;
+import static org.mockito.Mockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
 import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
-import org.mockito.Mock;
-import org.mockito.Mockito;
-import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -82,9 +73,9 @@ class KakeiboControllerTest {
 	void setUp() throws Exception {
 
 		// Listをセット
-		kakeibo.setId(1);
+		kakeibo.setId(1L);
 		kakeibo.setPaymentDate(LocalDate.parse("2022-11-13"));
-		kakeibo.setExpenseItemId(2);
+		kakeibo.setExpenseItemId(2L);
 		kakeibo.setExpenditureAmount(5000);
 		kakeibo.setIncomeAmount(0);
 
@@ -128,7 +119,7 @@ class KakeiboControllerTest {
 		doReturn(rateMap).when(service).calculatePercentage(integerToDoubleMap);
 
 	}
-	
+
 	@Test
 	@DisplayName("正常系：収支内訳表示のテスト（総収入・総支出・収支）")
 	void testBreakdownIncomeBalanceTotal() throws Exception {
@@ -144,9 +135,7 @@ class KakeiboControllerTest {
 		assertEquals(totalAmountMap, mavTotalAmountMap.getModel().get("totalAmountMap"));
 
 	}
-	
-	
-	
+
 	@Test
 	@DisplayName("正常系：収支内訳表示のテスト（月別の費目別）")
 	void testBreakdownIncomeBalanceItemExpense() throws Exception {
@@ -162,7 +151,7 @@ class KakeiboControllerTest {
 		assertEquals(itemExpenseMap, mavItemExpenseMap.getModel().get("itemExpenceMap"));
 
 	}
-	
+
 	@Test
 	@DisplayName("正常系：収支内訳表示のテスト（月別費目別の支出割合）")
 	void testBreakdownIncomeBalanceRate() throws Exception {
@@ -178,7 +167,7 @@ class KakeiboControllerTest {
 		assertEquals(rateMap, mavRateMap.getModel().get("rateItemMap"));
 
 	}
-	
+
 	@Test
 	@DisplayName("正常系：収支内訳表示のテスト（日付の確認）")
 	void testBreakdownIncomeBalanceDate() throws Exception {

--- a/src/test/java/com/example/controller/kakeibo/KakeiboControllerUpdateKakeiboTest.java
+++ b/src/test/java/com/example/controller/kakeibo/KakeiboControllerUpdateKakeiboTest.java
@@ -1,13 +1,9 @@
 package com.example.controller.kakeibo;
 
-import static org.mockito.ArgumentMatchers.anyLong;
-import static org.mockito.Mockito.when;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.model;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.redirectedUrl;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.view;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 import java.time.LocalDate;
 
@@ -30,22 +26,22 @@ import com.example.service.kakeibo.KakeiboService;
 @SpringBootTest
 @AutoConfigureMockMvc
 class KakeiboControllerUpdateKakeiboTest {
-	
+
 	Kakeibo kakeibo = new Kakeibo();
 	EditKakeiboForm editKakeiboForm = new EditKakeiboForm();
-	
+
 	@Autowired
 	private MockMvc mockMvc;
-	
+
 	@MockBean
 	private KakeiboService kakeiboService;
-	
+
 	@BeforeEach
 	void setUp() throws Exception {
 		// テスト準備
-		kakeibo.setId(1);
+		kakeibo.setId(1L);
 		kakeibo.setPaymentDate(LocalDate.parse("2022-11-04"));
-		kakeibo.setExpenseItemId(2);
+		kakeibo.setExpenseItemId(2L);
 		kakeibo.setExpenditureAmount(5000);
 		kakeibo.setIncomeAmount(0);
 		ExpenseItem expenseItem = new ExpenseItem();
@@ -56,7 +52,7 @@ class KakeiboControllerUpdateKakeiboTest {
 		settlement.setId(2);
 		settlement.setSettlementName("現金");
 		kakeibo.setSettlement(settlement);
-		
+
 		// DB登録情報を表示するためセット
 		editKakeiboForm.setId(1L);
 		editKakeiboForm.setPaymentDate(LocalDate.parse("2022-11-04"));
@@ -66,7 +62,7 @@ class KakeiboControllerUpdateKakeiboTest {
 		editKakeiboForm.setExpenseItem(expenseItem);
 		editKakeiboForm.setSettlement(settlement);
 	}
-	
+
 	/** editKakeibo(家計簿を更新する画面(edit.html)を表示)のテスト */
 
 	@Test
@@ -83,88 +79,88 @@ class KakeiboControllerUpdateKakeiboTest {
 				.andExpect(model().attribute("editKakeiboForm", editKakeiboForm))
 				.andExpect(view().name("kakeibo/edit"));
 	}
-	
+
 	/** updateKakeibo(家計簿を更新する処理)のテスト */
-	
+
 	// 異常系
-	
+
 	@Test
 	@DisplayName("決済日付がnullの時、更新に失敗する")
 	void testPaymentDateIsNull() throws Exception {
 		// 決済日付をnullでセット
 		editKakeiboForm.setPaymentDate(null);
-		
+
 		// 検証&実行
 		mockMvc.perform(post("/kakeibo/update")
 				.flashAttr("editKakeiboForm", editKakeiboForm))
-		.andExpect(model().hasErrors())
-		.andExpect(model().attributeHasErrors("editKakeiboForm"))
-		.andExpect(view().name("kakeibo/edit"));
+				.andExpect(model().hasErrors())
+				.andExpect(model().attributeHasErrors("editKakeiboForm"))
+				.andExpect(view().name("kakeibo/edit"));
 	}
-	
+
 	@Test
 	@DisplayName("費目IDがnullの時、更新に失敗する")
 	void testExpenseItemIdIsNull() throws Exception {
 		// 費目IDをnullでセット
 		editKakeiboForm.setExpenseItemId(null);
-		
+
 		// 検証&実行
 		mockMvc.perform(post("/kakeibo/update")
 				.flashAttr("editKakeiboForm", editKakeiboForm))
-		.andExpect(model().hasErrors())
-		.andExpect(model().attributeHasErrors("editKakeiboForm"))
-		.andExpect(view().name("kakeibo/edit"));
+				.andExpect(model().hasErrors())
+				.andExpect(model().attributeHasErrors("editKakeiboForm"))
+				.andExpect(view().name("kakeibo/edit"));
 	}
-	
+
 	@Test
 	@DisplayName("支出金額がnullの時、更新に失敗する")
 	void testExpenditureAmountIsNull() throws Exception {
 		// 支出金額をnullでセット
 		editKakeiboForm.setExpenditureAmount(null);
-		
+
 		// 検証&実行
 		mockMvc.perform(post("/kakeibo/update")
 				.flashAttr("editKakeiboForm", editKakeiboForm))
-		.andExpect(model().hasErrors())
-		.andExpect(model().attributeHasErrors("editKakeiboForm"))
-		.andExpect(view().name("kakeibo/edit"));
+				.andExpect(model().hasErrors())
+				.andExpect(model().attributeHasErrors("editKakeiboForm"))
+				.andExpect(view().name("kakeibo/edit"));
 	}
-	
+
 	@Test
 	@DisplayName("収入金額がnullの時、更新に失敗する")
 	void testIncomeAmountIsNull() throws Exception {
 		// 収入以外をnullでセット
 		editKakeiboForm.setIncomeAmount(null);
-		
+
 		// 検証&実行
 		mockMvc.perform(post("/kakeibo/update")
 				.flashAttr("editKakeiboForm", editKakeiboForm))
-		.andExpect(model().hasErrors())
-		.andExpect(model().attributeHasErrors("editKakeiboForm"))
-		.andExpect(view().name("kakeibo/edit"));
+				.andExpect(model().hasErrors())
+				.andExpect(model().attributeHasErrors("editKakeiboForm"))
+				.andExpect(view().name("kakeibo/edit"));
 	}
-	
+
 	// 正常系
-	
+
 	@Test
 	@DisplayName("入力項目に問題がない時、更新に成功する")
 	void testSuccess() throws Exception {
-		
+
 		// 更新する値をセット
 		editKakeiboForm.setPaymentDate(LocalDate.parse("2022-11-11"));
 		editKakeiboForm.setExpenseItemId(8);
 		editKakeiboForm.setExpenditureAmount(3000);
 		editKakeiboForm.setIncomeAmount(0);
-		
+
 		BeanUtils.copyProperties(editKakeiboForm, kakeibo);
-		
+
 		when(kakeiboService.updateKakeibo(kakeibo)).thenReturn(true);
-		
+
 		// 検証&実行
 		mockMvc.perform(post("/kakeibo/update")
 				.flashAttr("editKakeiboForm", editKakeiboForm))
-		.andExpect(model().hasNoErrors())
-		.andExpect(redirectedUrl("/kakeibo/list"));
+				.andExpect(model().hasNoErrors())
+				.andExpect(redirectedUrl("/kakeibo/list"));
 	}
 
 }

--- a/src/test/java/com/example/repository/kakeibo/KakeiboMapperSaveKakeiboTest.java
+++ b/src/test/java/com/example/repository/kakeibo/KakeiboMapperSaveKakeiboTest.java
@@ -25,10 +25,10 @@ class KakeiboMapperSaveKakeiboTest {
 
 	@BeforeEach
 	void setUp() throws Exception {
-		kakeibo.setUserId(1);
+		kakeibo.setUserId(1L);
 		LocalDate date = LocalDate.now();
 		kakeibo.setPaymentDate(date);
-		kakeibo.setExpenseItemId(1);
+		kakeibo.setExpenseItemId(1L);
 		kakeibo.setExpenditureAmount(10000);
 		kakeibo.setIncomeAmount(0);
 		kakeibo.setUsedStore("コンビニ");

--- a/src/test/java/com/example/repository/kakeibo/KakeiboMapperTest.java
+++ b/src/test/java/com/example/repository/kakeibo/KakeiboMapperTest.java
@@ -2,7 +2,7 @@ package com.example.repository.kakeibo;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-import java.util.ArrayList;
+import java.time.LocalDate;
 import java.util.List;
 
 import org.junit.jupiter.api.AfterAll;
@@ -13,12 +13,14 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
 
 import com.example.domain.kakeibo.Kakeibo;
 
 @SpringBootTest
+@Transactional
 class KakeiboMapperTest {
-	
+
 	@Autowired
 	KakeiboMapper mapper;
 
@@ -36,6 +38,31 @@ class KakeiboMapperTest {
 
 	@AfterEach
 	void tearDown() throws Exception {
+	}
+
+	@Test
+	@DisplayName("ユーザIDを渡したとき、適切なリストが得られることを期待する")
+	void whenGiveUserId_expectedToGetKakeiboList() {
+		// 準備
+		// テスト用ユーザIDの準備
+		var userId = 100;
+		// テストデータを100件作成
+		for (int i = 1; i <= 100; i++) {
+			var kakeibo = new Kakeibo();
+			kakeibo.setUserId(userId);
+			LocalDate date = LocalDate.now();
+			kakeibo.setPaymentDate(date);
+			kakeibo.setExpenseItemId(1);
+			kakeibo.setExpenditureAmount(10000);
+			kakeibo.setIncomeAmount(0);
+			mapper.saveKakeibo(kakeibo);
+		}
+		// 実行
+		var kakeiboList = mapper.findAll(100L);
+		// 検証
+		for (var kakeibo : kakeiboList) {
+			assertEquals(userId, kakeibo.getUserId());
+		}
 	}
 
 	@Test

--- a/src/test/java/com/example/repository/kakeibo/KakeiboMapperTest.java
+++ b/src/test/java/com/example/repository/kakeibo/KakeiboMapperTest.java
@@ -45,16 +45,17 @@ class KakeiboMapperTest {
 	void whenGiveUserId_expectedToGetKakeiboList() {
 		// 準備
 		// テスト用ユーザIDの準備
-		var userId = 100;
+		var userId = 100L;
 		// テストデータを100件作成
-		for (int i = 1; i <= 100; i++) {
+		for (int i = 1; i <= 10; i++) {
 			var kakeibo = new Kakeibo();
 			kakeibo.setUserId(userId);
 			LocalDate date = LocalDate.now();
 			kakeibo.setPaymentDate(date);
-			kakeibo.setExpenseItemId(1);
+			kakeibo.setExpenseItemId(1L);
 			kakeibo.setExpenditureAmount(10000);
 			kakeibo.setIncomeAmount(0);
+			kakeibo.setSettlementId(1L);
 			mapper.saveKakeibo(kakeibo);
 		}
 		// 実行

--- a/src/test/java/com/example/repository/kakeibo/KakeiboMapperUpdateKakeiboTest.java
+++ b/src/test/java/com/example/repository/kakeibo/KakeiboMapperUpdateKakeiboTest.java
@@ -15,84 +15,84 @@ import com.example.domain.kakeibo.Kakeibo;
 
 @SpringBootTest
 class KakeiboMapperUpdateKakeiboTest {
-	
+
 	private Kakeibo kakeibo;
-	
+
 	@Autowired
 	private KakeiboMapper kakeiboMapper;
-	
+
 	@BeforeEach
 	void setUp() throws Exception {
 		// IDが「1」の家計簿を取得
 		kakeibo = kakeiboMapper.findByKakeiboId(1L);
 	}
-	
+
 	/** 入力値チェックに問題がない場合、更新処理ができるかのテスト */
-	
+
 	// 異常系
-	
+
 	@Test
 	@DisplayName("決済日付がnullの時、例外を返す")
 	void testPaymentDateIsNull() throws Exception {
-		
+
 		// 更新後の値をセット
 		kakeibo.setPaymentDate(null);
-		
+
 		// 検証(例外がスローされるか)
 		assertThrows(DataIntegrityViolationException.class, () -> kakeiboMapper.update(kakeibo));
 	}
-	
+
 	@Test
 	@DisplayName("費目IDがnullの時、例外を返す")
 	void testExpenseItemIdIsNull() throws Exception {
-		
+
 		// 更新後の値をセット
 		kakeibo.setExpenseItemId(null);
-		
+
 		// 検証(例外がスローされるか)
 		assertThrows(DataIntegrityViolationException.class, () -> kakeiboMapper.update(kakeibo));
 	}
-	
+
 	@Test
 	@DisplayName("支出金額がnullの時、例外を返す")
 	void testExpenditureAmountIsNull() throws Exception {
-		
+
 		// 更新後の値をセット
 		kakeibo.setExpenditureAmount(null);
-		
+
 		// 検証(例外がスローされるか)
 		assertThrows(DataIntegrityViolationException.class, () -> kakeiboMapper.update(kakeibo));
 	}
-	
+
 	@Test
 	@DisplayName("収入金額がnullの時、例外を返す")
 	void testIncomeAmountIsNull() throws Exception {
-		
+
 		// 更新後の値をセット
 		kakeibo.setIncomeAmount(null);
-		
+
 		// 検証(例外がスローされるか)
 		assertThrows(DataIntegrityViolationException.class, () -> kakeiboMapper.update(kakeibo));
 	}
-	
+
 	// 正常系
 
 	@Test
 	@DisplayName("入力項目に問題がない時、更新に成功する")
 	void testSuccess() throws Exception {
-		
+
 		// 更新後の値をセット
 		kakeibo.setPaymentDate(LocalDate.parse("2022-11-11"));
-		kakeibo.setExpenseItemId(8);
+		kakeibo.setExpenseItemId(8L);
 		kakeibo.setExpenditureAmount(3000);
 		kakeibo.setIncomeAmount(0);
-		
+
 		// Mapperクラス実行
 		kakeiboMapper.update(kakeibo);
-		
+
 		// IDが「1」の更新後の家計簿を取得
 		Kakeibo updateKakeibo = kakeiboMapper.findByKakeiboId(1L);
-		
+
 		// 検証(更新後の値になっているか)
 		assertEquals(kakeibo.getPaymentDate(), updateKakeibo.getPaymentDate());
 		assertEquals(kakeibo.getExpenseItemId(), updateKakeibo.getExpenseItemId());

--- a/src/test/java/com/example/service/kakeibo/KakeiboServiceKakeiboByYearAndMonthTest.java
+++ b/src/test/java/com/example/service/kakeibo/KakeiboServiceKakeiboByYearAndMonthTest.java
@@ -1,8 +1,8 @@
 package com.example.service.kakeibo;
 
 import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.when;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
 
 import java.time.LocalDate;
 import java.util.ArrayList;
@@ -23,18 +23,18 @@ import com.example.repository.kakeibo.KakeiboMapper;
 
 @SpringBootTest
 class KakeiboServiceKakeiboByYearAndMonthTest {
-	
+
 	private List<Kakeibo> kakeiboList;
 	private Kakeibo kakeibo;
-	
+
 	@BeforeEach
 	void setUp() throws Exception {
 		// テスト準備(2022年11月のデータをセット)
 		kakeiboList = new ArrayList<>();
 		kakeibo = new Kakeibo();
-		kakeibo.setId(1);
+		kakeibo.setId(1L);
 		kakeibo.setPaymentDate(LocalDate.parse("2022-11-04"));
-		kakeibo.setExpenseItemId(2);
+		kakeibo.setExpenseItemId(2L);
 		kakeibo.setExpenditureAmount(5000);
 		kakeibo.setIncomeAmount(0);
 		ExpenseItem expenseItem = new ExpenseItem();
@@ -47,15 +47,15 @@ class KakeiboServiceKakeiboByYearAndMonthTest {
 		kakeibo.setSettlement(settlement);
 		kakeiboList.add(kakeibo);
 	}
-	
+
 	@InjectMocks
 	private KakeiboService kakeiboService;
-	
+
 	@Mock
 	private KakeiboMapper kakeiboMapper;
-	
+
 	// 異常系
-	
+
 	@Test
 	@DisplayName("該当年月が存在しない時、エラーメッセージを返す")
 	void testNotYearAndMonth() throws Exception {
@@ -65,7 +65,7 @@ class KakeiboServiceKakeiboByYearAndMonthTest {
 		// year:2022 , month:12 を渡す
 		assertNull(kakeiboService.findKakeiboByYearAndMonth("2022", "12"), "ご入力頂いた年月のデータは存在しません（年の指定は必須です）");
 	}
-	
+
 	// 正常系
 
 	@Test
@@ -78,7 +78,7 @@ class KakeiboServiceKakeiboByYearAndMonthTest {
 		// 検証
 		assertEquals(kakeiboList.getClass(), searchKakeiboList.getClass());
 	}
-	
+
 	@Test
 	@DisplayName("年のみ入力されている時のテスト")
 	void testMontIsNull() throws Exception {
@@ -89,17 +89,17 @@ class KakeiboServiceKakeiboByYearAndMonthTest {
 		// 検証
 		assertEquals(kakeiboList.getClass(), searchKakeiboList.getClass());
 	}
-	
+
 	@Test
 	@DisplayName("正常な値の時、収支計算結果を表示する")
 	void testMonthlyBalanceCalculationResult() throws Exception {
-		
+
 		// 収支結果に値をセット
 		MonthlyBalanceCalculationResult calc = new MonthlyBalanceCalculationResult();
 		calc.setTotalIncomeAmount(kakeibo.getIncomeAmount());
 		calc.setTotalExpenditureAmount(kakeibo.getExpenditureAmount());
 		calc.setBalanceCalculationResult(kakeibo.getIncomeAmount() - kakeibo.getExpenditureAmount());
-		
+
 		when(kakeiboMapper.monthlyBalanceCalculate(anyString(), anyString())).thenReturn(calc);
 		// year:2022 , month:11 を渡す
 		MonthlyBalanceCalculationResult result = kakeiboService.monthlyBalanceCalculate("2022", "11");

--- a/src/test/java/com/example/service/kakeibo/KakeiboServiceTest.java
+++ b/src/test/java/com/example/service/kakeibo/KakeiboServiceTest.java
@@ -1,14 +1,9 @@
 
 package com.example.service.kakeibo;
 
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.ArgumentMatchers.anyList;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.doReturn;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
 
 import java.time.LocalDate;
 import java.util.ArrayList;
@@ -16,18 +11,11 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.test.web.servlet.MockMvc;
 
 import com.example.domain.kakeibo.ExpenseItem;
 import com.example.domain.kakeibo.Kakeibo;
@@ -84,9 +72,9 @@ class KakeiboServiceTest {
 		// 期待するList
 		List<Kakeibo> kakeiboList = new ArrayList<>();
 		Kakeibo kakeibo = new Kakeibo();
-		kakeibo.setId(1);
+		kakeibo.setId(1L);
 		kakeibo.setPaymentDate(LocalDate.parse("2022-11-04"));
-		kakeibo.setExpenseItemId(2);
+		kakeibo.setExpenseItemId(2L);
 		kakeibo.setExpenditureAmount(5000);
 		kakeibo.setIncomeAmount(0);
 		ExpenseItem expenseItem = new ExpenseItem();
@@ -249,7 +237,7 @@ class KakeiboServiceTest {
 	@Test
 	@DisplayName("正常系：Map内の費目別の割合を計算し、Map<費目名,割合>を返す")
 	void testCalculatePercentage() throws Exception {
-		
+
 		// 期待するMapを生成
 		Map<String, Double> expectedPercentageMap = new HashMap<>();
 		expectedPercentageMap.put("食費", 50.0);
@@ -266,7 +254,7 @@ class KakeiboServiceTest {
 		assertEquals(percentageMap, serviceThroughPercentageMap);
 
 	}
-	
+
 	@Test
 	@DisplayName("異常系：Map内の費目別の割合を計算し、Map<費目名,割合>を返す")
 	void testCalculatePercentageMapNull() throws Exception {

--- a/src/test/java/com/example/service/kakeibo/KakeiboServiceUpdateKakeiboTest.java
+++ b/src/test/java/com/example/service/kakeibo/KakeiboServiceUpdateKakeiboTest.java
@@ -1,7 +1,7 @@
 package com.example.service.kakeibo;
 
 import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 import java.time.LocalDate;
 
@@ -20,15 +20,15 @@ import com.example.repository.kakeibo.KakeiboMapper;
 
 @SpringBootTest
 class KakeiboServiceUpdateKakeiboTest {
-	
+
 	private Kakeibo kakeibo;
-	
+
 	@BeforeEach
 	void setUp() throws Exception {
 		kakeibo = new Kakeibo();
-		kakeibo.setId(1);
+		kakeibo.setId(1L);
 		kakeibo.setPaymentDate(LocalDate.parse("2022-11-04"));
-		kakeibo.setExpenseItemId(2);
+		kakeibo.setExpenseItemId(2L);
 		kakeibo.setExpenditureAmount(5000);
 		kakeibo.setIncomeAmount(0);
 		ExpenseItem expenseItem = new ExpenseItem();
@@ -40,90 +40,90 @@ class KakeiboServiceUpdateKakeiboTest {
 		settlement.setSettlementName("現金");
 		kakeibo.setSettlement(settlement);
 	}
-	
+
 	@InjectMocks
 	private KakeiboService kakeiboService;
-	
+
 	@Mock
 	private KakeiboMapper kakeiboMapper;
-	
+
 	/** 入力値チェックに問題がない場合、更新処理ができるかのテスト */
-	
+
 	// 正常系
 
 	@Test
 	@DisplayName("入力項目に問題がない時、更新に成功する")
 	void testSuccess() throws Exception {
-		
+
 		// 更新後の値をセット
 		kakeibo.setPaymentDate(LocalDate.parse("2022-11-11"));
-		kakeibo.setExpenseItemId(8);
+		kakeibo.setExpenseItemId(8L);
 		kakeibo.setExpenditureAmount(3000);
 		kakeibo.setIncomeAmount(0);
-		
+
 		when(kakeiboMapper.update(kakeibo)).thenReturn(true);
-		
+
 		// 検証
 		boolean actual = kakeiboService.updateKakeibo(kakeibo);
 		assertTrue(actual);
 	}
-	
+
 	// 異常系
-	
-		@Test
-		@DisplayName("決済日付がnullの時、更新に失敗する")
-		void testPaymentDateIsNull() throws Exception {
-			
-			// 決済日付をnullでセット
-			kakeibo.setPaymentDate(null);
-			
-			when(kakeiboMapper.update(kakeibo)).thenThrow(new DataIntegrityViolationException(null));
-		
-			// 検証
-			boolean autual = kakeiboService.updateKakeibo(kakeibo);
-			assertFalse(autual);
-		}
-		
-		@Test
-		@DisplayName("費目IDがnullの時、更新に失敗する")
-		void testExpenseItemIdIsNull() throws Exception {
-			
-			// 費目IDをnullでセット
-			kakeibo.setExpenseItemId(null);
-			
-			when(kakeiboMapper.update(kakeibo)).thenThrow(new DataIntegrityViolationException(null));
-		
-			// 検証
-			boolean autual = kakeiboService.updateKakeibo(kakeibo);
-			assertFalse(autual);
-		}
-		
-		@Test
-		@DisplayName("支出金額がnullの時、更新に失敗する")
-		void testError() throws Exception {
-			
-			// 支出金額をnullでセット
-			kakeibo.setExpenditureAmount(null);
-			
-			when(kakeiboMapper.update(kakeibo)).thenThrow(new DataIntegrityViolationException(null));
-		
-			// 検証
-			boolean autual = kakeiboService.updateKakeibo(kakeibo);
-			assertFalse(autual);
-		}
-		
-		@Test
-		@DisplayName("収入金額がnullの時、更新に失敗する")
-		void testIncomeAmounIsNull() throws Exception {
-			
-			// 収入金額をnullでセット
-			kakeibo.setIncomeAmount(null);
-			
-			when(kakeiboMapper.update(kakeibo)).thenThrow(new DataIntegrityViolationException(null));
-		
-			// 検証
-			boolean autual = kakeiboService.updateKakeibo(kakeibo);
-			assertFalse(autual);
-		}
+
+	@Test
+	@DisplayName("決済日付がnullの時、更新に失敗する")
+	void testPaymentDateIsNull() throws Exception {
+
+		// 決済日付をnullでセット
+		kakeibo.setPaymentDate(null);
+
+		when(kakeiboMapper.update(kakeibo)).thenThrow(new DataIntegrityViolationException(null));
+
+		// 検証
+		boolean autual = kakeiboService.updateKakeibo(kakeibo);
+		assertFalse(autual);
+	}
+
+	@Test
+	@DisplayName("費目IDがnullの時、更新に失敗する")
+	void testExpenseItemIdIsNull() throws Exception {
+
+		// 費目IDをnullでセット
+		kakeibo.setExpenseItemId(null);
+
+		when(kakeiboMapper.update(kakeibo)).thenThrow(new DataIntegrityViolationException(null));
+
+		// 検証
+		boolean autual = kakeiboService.updateKakeibo(kakeibo);
+		assertFalse(autual);
+	}
+
+	@Test
+	@DisplayName("支出金額がnullの時、更新に失敗する")
+	void testError() throws Exception {
+
+		// 支出金額をnullでセット
+		kakeibo.setExpenditureAmount(null);
+
+		when(kakeiboMapper.update(kakeibo)).thenThrow(new DataIntegrityViolationException(null));
+
+		// 検証
+		boolean autual = kakeiboService.updateKakeibo(kakeibo);
+		assertFalse(autual);
+	}
+
+	@Test
+	@DisplayName("収入金額がnullの時、更新に失敗する")
+	void testIncomeAmounIsNull() throws Exception {
+
+		// 収入金額をnullでセット
+		kakeibo.setIncomeAmount(null);
+
+		when(kakeiboMapper.update(kakeibo)).thenThrow(new DataIntegrityViolationException(null));
+
+		// 検証
+		boolean autual = kakeiboService.updateKakeibo(kakeibo);
+		assertFalse(autual);
+	}
 
 }


### PR DESCRIPTION
#102

### 確認していただきたい点
* 家計簿リストを表示する際にログインをしていないと、ログイン画面にリダイレクトするように変更しました。
* ユーザーIDで家計簿一覧を取得するように変更したため、家計簿一覧表示のテストを追加しました。
* サービス、コントローラのテストは実装しておりません。