### PR TITLE
家計簿追加の際、ログインユーザーのIDで登録されるように変更

### DIFF
--- a/src/main/java/com/example/controller/applicationController.java
+++ b/src/main/java/com/example/controller/applicationController.java
@@ -1,0 +1,28 @@
+package com.example.controller;
+
+import javax.servlet.http.HttpSession;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+
+import com.example.domain.user.User;
+
+@Controller
+public class applicationController {
+
+	@Autowired
+	HttpSession session;
+
+	/** Webアプリを開いた際にログイン画面を表示するよう */
+	@GetMapping("/")
+	public String index() {
+		// ログインチェックを追加
+		User user = (User) session.getAttribute("user");
+		if (user == null) {
+			return "redirect:/user/login";
+		}
+		return "redirect:/kakeibo/list";
+	}
+
+}

--- a/src/main/java/com/example/controller/kakeibo/KakeiboController.java
+++ b/src/main/java/com/example/controller/kakeibo/KakeiboController.java
@@ -5,6 +5,8 @@ import java.time.format.DateTimeFormatter;
 import java.util.List;
 import java.util.Map;
 
+import javax.servlet.http.HttpSession;
+
 import org.springframework.beans.BeanUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.format.annotation.DateTimeFormat;
@@ -21,6 +23,7 @@ import org.springframework.web.bind.annotation.RequestMethod;
 
 import com.example.domain.kakeibo.DeletedKakeibo;
 import com.example.domain.kakeibo.Kakeibo;
+import com.example.domain.user.User;
 import com.example.form.kakeibo.AddKakeiboForm;
 import com.example.form.kakeibo.EditKakeiboForm;
 import com.example.form.kakeibo.SearchKakeiboForm;
@@ -30,6 +33,9 @@ import com.example.service.user.LoginService;
 @Controller
 @RequestMapping("/kakeibo")
 public class KakeiboController {
+
+	@Autowired
+	HttpSession session;
 
 	@Autowired
 	KakeiboService kakeiboService;
@@ -62,12 +68,24 @@ public class KakeiboController {
 	/** 家計簿を追加する画面(register.html)を表示 */
 	@GetMapping("/registerKakeibo")
 	public String getRegisterKakeibo(@ModelAttribute AddKakeiboForm form) {
+		// ログインチェックを追加
+		User user = (User) session.getAttribute("user");
+		if (user == null) {
+			return "redirect:/user/login";
+		}
+
 		return "kakeibo/register";
 	}
 
 	/** 家計簿の追加処理 */
 	@PostMapping("/saveKakeibo")
 	public String saveKakeibo(@ModelAttribute @Validated AddKakeiboForm form, BindingResult result, Model model) {
+		// ログインチェックを追加
+		User user = (User) session.getAttribute("user");
+		if (user == null) {
+			return "redirect:/user/login";
+		}
+
 		// 入力値チェック
 		if (result.hasErrors()) {
 			return getRegisterKakeibo(form);

--- a/src/main/java/com/example/controller/user/LoginController.java
+++ b/src/main/java/com/example/controller/user/LoginController.java
@@ -22,15 +22,15 @@ public class LoginController {
 
 	@Autowired
 	private LoginService service;
-	
+
 	@Autowired
 	private HttpSession session;
-	
+
 	@ModelAttribute
 	public LoginForm setUpLoginForm() {
 		return new LoginForm();
 	}
-	
+
 	/**
 	 * ログイン画面に遷移(user/login.html)
 	 * 
@@ -38,10 +38,10 @@ public class LoginController {
 	 */
 	@GetMapping("/login")
 	public String getLogin() {
-		
+
 		return "user/login";
 	}
-	
+
 	/**
 	 * ログイン処理
 	 * 成功時：家計簿一覧表示(kakeibo/list.html)
@@ -53,14 +53,14 @@ public class LoginController {
 	 */
 	@PostMapping("/login")
 	public String postLogin(@Validated LoginForm loginForm, BindingResult result, Model model) {
-		
+
 		// 入力値チェック
 		if (result.hasErrors()) {
 			return getLogin();
 		}
-		
+
 		User user = service.login(loginForm.getMailAddress(), loginForm.getPassword());
-		
+
 		if (user == null) {
 			model.addAttribute("errorMessage", "メールアドレスまたはパスワードが不正です");
 			return "user/login";
@@ -68,6 +68,13 @@ public class LoginController {
 			session.setAttribute("user", user);
 			return "redirect:/kakeibo/list";
 		}
+	}
+
+	@PostMapping("/test/login")
+	public String testLogin() {
+		User user = service.login("aaa@aaa", "test1");
+		session.setAttribute("user", user);
+		return "redirect:/kakeibo/list";
 	}
 
 }

--- a/src/main/resources/templates/kakeibo/register.html
+++ b/src/main/resources/templates/kakeibo/register.html
@@ -28,8 +28,8 @@
                 <!-- 登録が失敗した場合、エラーメッセージを表示する -->
                 <div th:if="${errorMessage}" th:text="${errorMessage}" style="color: red;"></div>
                 <form th:action="@{/kakeibo/saveKakeibo}" th:object="${addKakeiboForm}" method="post">
-                    <!-- ユーザーID(とりあえずダミーを使用(ID=1)) -->
-                    <input type="hidden" value="1" name="userId">
+                    <!-- ログインユーザーのユーザーID) -->
+                    <input type="hidden" th:value=${session.user.id} name="userId">
                     <!-- 決済日時 -->
                     <div th:errors="*{paymentDate}" style="color: red;"></div>
                     <div class="inputs">

--- a/src/main/resources/templates/user/login.html
+++ b/src/main/resources/templates/user/login.html
@@ -23,6 +23,11 @@
             display: table-cell;
             vertical-align: middle;
         }
+
+        .test-btn {
+            margin-top: 20px;
+            text-align: center;
+        }
     </style>
 </head>
 
@@ -41,6 +46,11 @@
             <p class="card-text"><button class="btn btn-primary" type="submit">ログイン</button></p>
             <p class="card-text"><a th:href="@{/user/signup}">新規登録はこちら</a></p>
         </div>
+    </form>
+
+    <!-- テスト用ユーザーでの簡易ログインボタン -->
+    <form class="test-btn" th:action="@{/user/test/login}" method="post">
+        <button class="btn btn-primary" type="submit">テストユーザ(1)としてログイン</button>
     </form>
 </body>
 


### PR DESCRIPTION
#102
### いくつかの追加実装を行いました。
* URLに( / )を入力した際に「ログイン画面」または「家計簿一覧」に遷移するコントローラを追加
* 家計簿を追加する処理に関してログインを必須に
※ 上記2つは"SpringSecurity"の導入後は必要ないかも？
* 家計簿を追加する際に、ログイン情報からユーザーIDを渡すように変更
* ログイン画面にテストユーザー( ユーザIDが1 )でログインできるボタンを追加(毎回の入力が面倒だったため)

### 何か気になる点があれば、ご指摘お願いします。