### PR TITLE
新規投稿機能に関するテストを実装

### DIFF
--- a/src/main/java/com/example/domain/post/Post.java
+++ b/src/main/java/com/example/domain/post/Post.java
@@ -2,6 +2,7 @@ package com.example.domain.post;
 
 import java.time.LocalDateTime;
 
+import com.example.domain.board.Board;
 import com.example.domain.user.User;
 
 import lombok.Data;
@@ -19,8 +20,7 @@ public class Post {
 	private LocalDateTime updateAt;
 	/** ユーザー情報 */
 	private User user;
-
-	// board未作成のため
-	// private Board board;
+	/** 掲示板情報 */
+	private Board board;
 
 }

--- a/src/main/java/com/example/form/post/NewPostForm.java
+++ b/src/main/java/com/example/form/post/NewPostForm.java
@@ -5,4 +5,8 @@ import lombok.Data;
 @Data
 public class NewPostForm {
 
+	private Long userId;
+	private Long boardId;
+	private String contents;
+
 }

--- a/src/main/java/com/example/repository/post/PostMapper.java
+++ b/src/main/java/com/example/repository/post/PostMapper.java
@@ -14,4 +14,6 @@ public interface PostMapper {
 	 */
 	public List<Post> findPostList(Long boardId);
 
+	public boolean savePost(Post post) throws Exception;
+
 }

--- a/src/main/java/com/example/service/post/PostService.java
+++ b/src/main/java/com/example/service/post/PostService.java
@@ -8,4 +8,6 @@ public interface PostService {
 
 	List<Post> selectPostList(Long boardId);
 
+	public boolean savePost(Post post);
+
 }

--- a/src/main/java/com/example/service/post/impl/PostServiceImpl.java
+++ b/src/main/java/com/example/service/post/impl/PostServiceImpl.java
@@ -13,10 +13,10 @@ import com.example.service.post.PostService;
 @Service
 @Transactional
 public class PostServiceImpl implements PostService {
-	
+
 	@Autowired
 	private PostMapper postMapper;
-	
+
 	/*
 	 * 掲示板IDでトピックごとの投稿一覧を取得
 	 */
@@ -25,5 +25,11 @@ public class PostServiceImpl implements PostService {
 
 		return postMapper.findPostList(boardId);
 	}
-	
+
+	@Override
+	public boolean savePost(Post post) {
+		// TODO 自動生成されたメソッド・スタブ
+		return false;
+	}
+
 }

--- a/src/test/java/com/example/controller/post/PostControllerTest.java
+++ b/src/test/java/com/example/controller/post/PostControllerTest.java
@@ -1,0 +1,142 @@
+package com.example.controller.post;
+
+import static org.hamcrest.CoreMatchers.*;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.mock.web.MockHttpSession;
+import org.springframework.test.web.servlet.MockMvc;
+
+import com.example.domain.board.Board;
+import com.example.domain.post.Post;
+import com.example.domain.user.User;
+import com.example.form.post.NewPostForm;
+import com.example.service.post.impl.PostServiceImpl;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+class PostControllerTest {
+
+	static final MockHttpSession mockHttpSession = new MockHttpSession();
+	static final User user = new User();
+	static final Board board = new Board();
+
+	NewPostForm newPostForm = new NewPostForm();
+	Post newPost = new Post();
+
+	@Autowired
+	MockMvc mockMvc;
+
+	@MockBean
+	PostServiceImpl service;
+
+	@BeforeAll
+	static void setUpBeforeClass() throws Exception {
+		// ユーザー情報の準備
+		user.setId(1L);
+		user.setMailAddress("test@gmail.com");
+		user.setPassword("validPassword");
+		// 掲示板情報の準備
+		board.setId(1L);
+		// Session情報セット
+		mockHttpSession.setAttribute("user", user);
+	}
+
+	@BeforeEach
+	void setUp() throws Exception {
+		// 有効なフォーム情報を準備
+		newPostForm.setUserId(user.getId());
+		newPostForm.setBoardId(board.getId());
+		newPostForm.setContents("テストデータ");
+	}
+
+	@Test
+	@DisplayName("投稿の新規登録画面に遷移することを期待する")
+	void showNewPostPageIsSuccess() throws Exception {
+		// 準備
+		var emptyForm = new NewPostForm();
+		// 実行&検証
+		var result = mockMvc.perform(get("/board/" + board.getId() + "/newPost")
+				.flashAttr("newPostForm", emptyForm)
+				.session(mockHttpSession))
+				.andExpect(view().name("newPost"))
+				.andExpect(status().isOk())
+				.andReturn();
+		var model = result.getModelAndView();
+		// 空のフォームと掲示板IDがModelに格納されていることを確認
+		assertEquals(emptyForm, model.getModel().get("newPostForm"));
+		assertEquals(board.getId(), model.getModel().get("boardId"));
+	}
+
+	@Test
+	@DisplayName("フォームの値が正しいとき、新規投稿が成功し投稿一覧にリダイレクトする")
+	void whenValidInformation_savePostIsSuccess() throws Exception {
+		// 準備
+		when(service.savePost(newPost)).thenReturn(true);
+		// 実行&検証
+		mockMvc.perform(post("/newPost")
+				.flashAttr("newPostForm", newPostForm)
+				.session(mockHttpSession)
+				)
+		.andExpect(model().hasNoErrors())
+		.andExpect(redirectedUrl("/board/" + board.getId()))
+		.andExpect(status().isFound())
+		.andExpect(content().string(containsString("新規投稿に成功しました")));
+	}
+
+	@Test
+	@DisplayName("ユーザIDがNULLなとき、新規投稿が失敗し新規投稿画面に遷移する")
+	void whenUserIdIsNull_savePostIsFailed() throws Exception {
+		// 準備
+		newPostForm.setUserId(null);
+		// 実行&検証
+		mockMvc.perform(post("/newPost")
+				.flashAttr("newPostForm", newPostForm)
+				.session(mockHttpSession))
+				.andExpect(model().hasErrors())
+				.andExpect(view().name("newPost"))
+				.andExpect(status().isOk())
+				.andExpect(content().string(containsString("新規投稿に失敗しました")));
+	}
+
+	@Test
+	@DisplayName("掲示板IDがNULLなとき、新規投稿が失敗し新規投稿画面に遷移する")
+	void whenBoardIdIsNull_savePostIsFailed() throws Exception {
+		// 準備
+		newPostForm.setBoardId(null);
+		// 実行&検証
+		mockMvc.perform(post("/newPost")
+				.flashAttr("newPostForm", newPostForm)
+				.session(mockHttpSession))
+				.andExpect(model().hasErrors())
+				.andExpect(view().name("newPost"))
+				.andExpect(status().isOk())
+				.andExpect(content().string(containsString("新規投稿に失敗しました")));
+	}
+
+	@Test
+	@DisplayName("内容(コンテンツ)がNULLなとき、新規投稿が失敗し新規投稿画面に遷移する")
+	void whenContentsIsNull_savePostIsFailed() throws Exception {
+		// 準備
+		newPostForm.setContents(null);
+		// 実行&検証
+		mockMvc.perform(post("/newPost")
+				.flashAttr("newPostForm", newPostForm)
+				.session(mockHttpSession))
+				.andExpect(model().hasErrors())
+				.andExpect(view().name("newPost"))
+				.andExpect(status().isOk())
+				.andExpect(content().string(containsString("新規投稿に失敗しました")));
+	}
+
+}

--- a/src/test/java/com/example/repository/post/PostMapperTest.java
+++ b/src/test/java/com/example/repository/post/PostMapperTest.java
@@ -14,7 +14,9 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
 
+import com.example.domain.board.Board;
 import com.example.domain.post.Post;
 import com.example.domain.user.User;
 
@@ -22,16 +24,18 @@ import lombok.extern.slf4j.Slf4j;
 
 @SpringBootTest
 @Slf4j
+@Transactional
 class PostMapperTest {
-	
+
 	@Autowired
 	PostMapper mapper;
-	
+
 	Post post1 = new Post();
 	Post post2 = new Post();
 	Post post3 = new Post();
 	List<Post> expectedPostLists = new ArrayList<Post>();
 	User user = new User();
+	Board board = new Board();
 
 	@BeforeAll
 	static void setUpBeforeClass() throws Exception {
@@ -43,39 +47,45 @@ class PostMapperTest {
 
 	@BeforeEach
 	void setUp() throws Exception {
-		
+
 		LocalDateTime insertDateTime4 = LocalDateTime.parse("2022-04-09T19:34:50.63");
 		LocalDateTime insertDateTime5 = LocalDateTime.parse("2022-05-09T19:34:50.63");
 		LocalDateTime insertDateTime6 = LocalDateTime.parse("2022-06-09T19:34:50.63");
 		LocalDateTime updateDateTime4 = LocalDateTime.parse("2022-04-10T19:34:50.63");
 		LocalDateTime updateDateTime5 = LocalDateTime.parse("2022-05-10T19:34:50.63");
 		LocalDateTime updateDateTime6 = LocalDateTime.parse("2022-06-10T19:34:50.63");
+		// ユーザー情報
 		user.setId(1L);
 		user.setMailAddress("aaa@aaa");
 		user.setPassword("test1");
-		
+		// 掲示板情報
+		board.setId(1L);
+
 		post1.setId(4L);
 		post1.setContents("ボーナスやった！！(4)");
 		post1.setInsertAt(insertDateTime4);
 		post1.setUpdateAt(updateDateTime4);
 		post1.setUser(user);
-		
+		post1.setBoard(board);
+
 		post2.setId(5L);
 		post2.setContents("ボーナスやった！！(5)");
 		post2.setInsertAt(insertDateTime5);
 		post2.setUpdateAt(updateDateTime5);
 		post2.setUser(user);
-		
+		post1.setBoard(board);
+
 		post3.setId(6L);
 		post3.setContents("ボーナスやった！！(6)");
 		post3.setInsertAt(insertDateTime6);
 		post3.setUpdateAt(updateDateTime6);
 		post3.setUser(user);
-		
+		post1.setBoard(board);
+
 		expectedPostLists.add(post1);
 		expectedPostLists.add(post2);
 		expectedPostLists.add(post3);
-		
+
 	}
 
 	@AfterEach
@@ -85,47 +95,91 @@ class PostMapperTest {
 	@Test
 	@DisplayName("期待する投稿一覧のリストが返されているか")
 	void testFindPostList() {
-		
+
 		List<Post> mapperPostList = mapper.findPostList(3L);
-		
+
 		//期待する投稿一覧リストの0,1番目から投稿IDを抽出する
 		Long expectedPostId0 = expectedPostLists.get(0).getId();
 		Long expectedPostId1 = expectedPostLists.get(1).getId();
-		
+
 		//mapperから返された投稿一覧リストの0,1番目から投稿IDを抽出する
 		Long mapperPostId0 = mapperPostList.get(2).getId();
 		Long mapperPostId1 = mapperPostList.get(1).getId();
-				
+
 		//Listのsizeを比較する
 		assertEquals(3, mapperPostList.size());
 		//投稿IDが一致するかどうか
 		assertEquals(expectedPostId0, mapperPostId0);
 		assertEquals(expectedPostId1, mapperPostId1);
-		
+
 	}
-	
+
 	@Test
 	@DisplayName("存在しない掲示板番号(bordId)を渡した時、sizeが0のリストが返ってくるか")
 	void testFindPostListSizeZero() {
-		
+
 		//存在しない掲示板番号(bordId)を引数に渡す
 		List<Post> mapperPostList = mapper.findPostList(100L);
-		
+
 		//size()が0になっている場合正常にテストが通る
-		assertEquals(0,mapperPostList.size());
-		
+		assertEquals(0, mapperPostList.size());
+
 	}
-	
+
 	@Test
 	@DisplayName("投稿一覧のリストが投稿日順に並んで返されているか")
 	void testFindPostListOrderByDate() {
-		
+
 		List<Post> mapperPostList = mapper.findPostList(3L);
-		
+
 		//期待する投稿とmapperから返された投稿一が同じものを比較する
-		assertEquals(post3.getId(),mapperPostList.get(0).getId());
-		assertEquals(post2.getId(),mapperPostList.get(1).getId());
-		assertEquals(post1.getId(),mapperPostList.get(2).getId());
+		assertEquals(post3.getId(), mapperPostList.get(0).getId());
+		assertEquals(post2.getId(), mapperPostList.get(1).getId());
+		assertEquals(post1.getId(), mapperPostList.get(2).getId());
+	}
+
+	@Test
+	@DisplayName("新規投稿に成功したとき、戻り値にTrueを返すことを期待する")
+	void whenSavePostIsSuccess_expectedSizePlus1() {
+		// 準備
+		boolean actual;
+		// 実行
+		try {
+			actual = mapper.savePost(post1);
+		} catch (Exception e) {
+			actual = false;
+		}
+		// 検証
+		assertTrue(actual);
+	}
+
+	@Test
+	@DisplayName("ユーザーIDがNULLのとき、例外が発生することを期待する")
+	void whenUserIdIsNull_whenThrowException() {
+		// 準備
+		var invalidUser = new User();
+		post1.setUser(invalidUser);
+		// 実行&検証
+		assertThrows(Exception.class, () -> mapper.savePost(post1));
+	}
+
+	@Test
+	@DisplayName("掲示板IDがNULLのとき、例外が発生することを期待する")
+	void whenBoardIdIsNull_whenThrowException() {
+		// 準備
+		var invalidBoard = new Board();
+		post1.setBoard(invalidBoard);
+		// 実行&検証
+		assertThrows(Exception.class, () -> mapper.savePost(post1));
+	}
+
+	@Test
+	@DisplayName("内容(contents)がNULLのとき、例外が発生することを期待する")
+	void whenContentsIsNull_whenThrowException() {
+		// 準備
+		post1.setContents(null);
+		// 実行&検証
+		assertThrows(Exception.class, () -> mapper.savePost(post1));
 	}
 
 }

--- a/src/test/java/com/example/repository/post/PostMapperTest.java
+++ b/src/test/java/com/example/repository/post/PostMapperTest.java
@@ -73,14 +73,14 @@ class PostMapperTest {
 		post2.setInsertAt(insertDateTime5);
 		post2.setUpdateAt(updateDateTime5);
 		post2.setUser(user);
-		post1.setBoard(board);
+		post2.setBoard(board);
 
 		post3.setId(6L);
 		post3.setContents("ボーナスやった！！(6)");
 		post3.setInsertAt(insertDateTime6);
 		post3.setUpdateAt(updateDateTime6);
 		post3.setUser(user);
-		post1.setBoard(board);
+		post3.setBoard(board);
 
 		expectedPostLists.add(post1);
 		expectedPostLists.add(post2);

--- a/src/test/java/com/example/service/post/impl/PostServiceImplTest.java
+++ b/src/test/java/com/example/service/post/impl/PostServiceImplTest.java
@@ -1,8 +1,8 @@
 package com.example.service.post.impl;
 
 import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.ArgumentMatchers.anyLong;
-import static org.mockito.Mockito.doReturn;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
 
 import java.time.LocalDateTime;
 import java.util.ArrayList;
@@ -24,19 +24,19 @@ import com.example.repository.post.PostMapper;
 
 @SpringBootTest
 class PostServiceImplTest {
-	
+
 	@InjectMocks
 	private PostServiceImpl serviceImpl;
-	
+
 	@Mock
 	private PostMapper mapper;
-	
+
 	Post post1 = new Post();
 	Post post2 = new Post();
 	Post post3 = new Post();
 	List<Post> postLists = new ArrayList<Post>();
 	User user = new User();
-	
+
 	@BeforeAll
 	static void setUpBeforeClass() throws Exception {
 	}
@@ -54,29 +54,29 @@ class PostServiceImplTest {
 		user.setId(1L);
 		user.setMailAddress("aaa@aaa");
 		user.setPassword("test1");
-		
+
 		post1.setId(4L);
 		post1.setContents("ボーナスやった！！(4)");
 		post1.setInsertAt(insertDateTime4);
 		post1.setUpdateAt(updateDateTime);
 		post1.setUser(user);
-		
+
 		post2.setId(5L);
 		post2.setContents("ボーナスやった！！(5)");
 		post2.setInsertAt(insertDateTime5);
 		post2.setUpdateAt(updateDateTime);
 		post2.setUser(user);
-		
+
 		post3.setId(6L);
 		post3.setContents("ボーナスやった！！(6)");
 		post3.setInsertAt(insertDateTime6);
 		post3.setUpdateAt(updateDateTime);
 		post3.setUser(user);
-		
+
 		postLists.add(post1);
 		postLists.add(post2);
 		postLists.add(post3);
-		
+
 	}
 
 	@AfterEach
@@ -94,6 +94,28 @@ class PostServiceImplTest {
 		List<Post> servicePostLists = serviceImpl.selectPostList(3L);
 		
 		assertEquals(postLists, servicePostLists);
+	}
+
+	@Test
+	@DisplayName("新規投稿に成功したとき、戻り値でTrueを返すことを期待する")
+	void whenSavePostIsSuccess_expectedToReturnTrue() throws Exception {
+		// 準備
+		when(mapper.savePost(post1)).thenReturn(true);
+		// 実行
+		var actual = serviceImpl.savePost(post1);
+		// 検証
+		assertTrue(actual);
+	}
+
+	@Test
+	@DisplayName("新規投稿に失敗したとき、戻り値でFalseを返すことを期待する")
+	void whenSavePostIsFailed_expectedToReturnFalse() throws Exception {
+		// 準備
+		when(mapper.savePost(post1)).thenThrow(Exception.class);
+		// 実行
+		var actual = serviceImpl.savePost(post1);
+		// 検証
+		assertFalse(actual);
 	}
 
 }


### PR DESCRIPTION
### 全体の追加内容
* Postドメインにフィールド変数"Board"を追加
* NewPostFormのフィールド変数を追加

### MyBatisのテスト 4つ (141行以降をご確認ください)
* 新規投稿(成功)Trueを返す
* ユーザーID、掲示板ID、内容(contents)がNullのとき(失敗)、例外が発生することを確認
* (注)設計にあった「投稿件数が1件増える」のテストはまだ実装しておりません。

### Serviceのテスト 2つ
* 新規投稿(成功)trueを返す
* 新規投稿(失敗)falseを返す

### Controllerのテスト 5つ
* 前提条件(ユーザーはログイン済み、ユーザー情報と掲示板情報は定数で固定)
* 投稿画面への遷移(成功のみ)、遷移ページとModelのチェック
* 新規投稿(成功)、正しくリダイレクトされる
* バリデーションチェック(失敗)、(ユーザーID、掲示板ID、内容がNULL)で新規投稿画面に戻る

### 確認して欲しい内容
実装がまだないので、テストは全て通りません。
実装が完了後、テストの実施および修正を行いますので、現時点で気になることがあればご指摘お願いします。