### PR TITLE
投稿の削除に関するテストを実装

### DIFF
--- a/src/main/java/com/example/repository/post/PostMapper.java
+++ b/src/main/java/com/example/repository/post/PostMapper.java
@@ -14,4 +14,6 @@ public interface PostMapper {
 	 */
 	public List<Post> findPostList(Long boardId);
 
+	public boolean deletePost(Long postId) throws Exception;
+
 }

--- a/src/main/java/com/example/service/post/PostService.java
+++ b/src/main/java/com/example/service/post/PostService.java
@@ -8,4 +8,5 @@ public interface PostService {
 
 	List<Post> selectPostList(Long boardId);
 
+	public boolean deletePost(Long boardId);
 }

--- a/src/main/java/com/example/service/post/impl/PostServiceImpl.java
+++ b/src/main/java/com/example/service/post/impl/PostServiceImpl.java
@@ -13,10 +13,10 @@ import com.example.service.post.PostService;
 @Service
 @Transactional
 public class PostServiceImpl implements PostService {
-	
+
 	@Autowired
 	private PostMapper postMapper;
-	
+
 	/*
 	 * 掲示板IDでトピックごとの投稿一覧を取得
 	 */
@@ -25,5 +25,11 @@ public class PostServiceImpl implements PostService {
 
 		return postMapper.findPostList(boardId);
 	}
-	
+
+	@Override
+	public boolean deletePost(Long boardId) {
+		// TODO 自動生成されたメソッド・スタブ
+		return false;
+	}
+
 }

--- a/src/test/java/com/example/controller/post/PostControllerTest.java
+++ b/src/test/java/com/example/controller/post/PostControllerTest.java
@@ -53,8 +53,8 @@ class PostControllerTest {
 		when(postService.deletePost(postId)).thenReturn(true);
 		// 実行&検証
 		mockMvc.perform(post("/deletePost")
-				.flashAttr("postId", "postId")
-				.flashAttr("boardId", "boardId")
+				.param("postId", "1L")
+				.param("boardId", "1L")
 				.session(mockHttpSession)
 				)
 		.andExpect(redirectedUrl("/board/" + boardId))
@@ -69,8 +69,8 @@ class PostControllerTest {
 		when(postService.deletePost(postId)).thenReturn(false);
 		// 実行&検証
 		mockMvc.perform(post("/deletePost")
-				.flashAttr("postId", "postId")
-				.flashAttr("boardId", "boardId")
+				.param("postId", "1L")
+				.param("boardId", "1L")
 				.session(mockHttpSession)
 				)
 		.andExpect(redirectedUrl("/board/" + boardId))

--- a/src/test/java/com/example/controller/post/PostControllerTest.java
+++ b/src/test/java/com/example/controller/post/PostControllerTest.java
@@ -53,8 +53,8 @@ class PostControllerTest {
 		when(postService.deletePost(postId)).thenReturn(true);
 		// 実行&検証
 		mockMvc.perform(post("/deletePost")
-				.param("postId", "postId")
-				.param("boardId", "boardId")
+				.flashAttr("postId", "postId")
+				.flashAttr("boardId", "boardId")
 				.session(mockHttpSession)
 				)
 		.andExpect(redirectedUrl("/board/" + boardId))
@@ -69,8 +69,8 @@ class PostControllerTest {
 		when(postService.deletePost(postId)).thenReturn(false);
 		// 実行&検証
 		mockMvc.perform(post("/deletePost")
-				.param("postId", "postId")
-				.param("boardId", "boardId")
+				.flashAttr("postId", "postId")
+				.flashAttr("boardId", "boardId")
 				.session(mockHttpSession)
 				)
 		.andExpect(redirectedUrl("/board/" + boardId))

--- a/src/test/java/com/example/controller/post/PostControllerTest.java
+++ b/src/test/java/com/example/controller/post/PostControllerTest.java
@@ -1,0 +1,81 @@
+package com.example.controller.post;
+
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.mock.web.MockHttpSession;
+import org.springframework.test.web.servlet.MockMvc;
+
+import com.example.domain.user.User;
+import com.example.service.post.impl.PostServiceImpl;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+class PostControllerTest {
+
+	static final MockHttpSession mockHttpSession = new MockHttpSession();
+	static final User user = new User();
+	static final Long postId = 1L;
+	static final Long boardId = 1L;
+
+	@Autowired
+	MockMvc mockMvc;
+
+	@MockBean
+	PostServiceImpl postService;
+
+	@BeforeAll
+	static void setUpBeforeClass() throws Exception {
+		// ユーザー情報の準備
+		user.setId(1L);
+		// Session情報セット
+		mockHttpSession.setAttribute("user", user);
+	}
+
+	@BeforeEach
+	void setUp() throws Exception {
+	}
+
+	@Test
+	@DisplayName("投稿の削除に成功したとき、成功メッセージを表示する")
+	void whenDeletePostIsSuccess_showSuccessMessage() throws Exception {
+		// 準備
+		when(postService.deletePost(postId)).thenReturn(true);
+		// 実行&検証
+		mockMvc.perform(post("/deletePost")
+				.param("postId", "postId")
+				.param("boardId", "boardId")
+				.session(mockHttpSession)
+				)
+		.andExpect(redirectedUrl("/board/" + boardId))
+		.andExpect(status().isFound())
+		.andExpect(content().string(contains("投稿を削除しました")));
+	}
+
+	@Test
+	@DisplayName("投稿の削除に失敗したとき、失敗メッセージを表示する")
+	void whenDeletePostIsFailed_showFailMessage() throws Exception {
+		// 準備
+		when(postService.deletePost(postId)).thenReturn(false);
+		// 実行&検証
+		mockMvc.perform(post("/deletePost")
+				.param("postId", "postId")
+				.param("boardId", "boardId")
+				.session(mockHttpSession)
+				)
+		.andExpect(redirectedUrl("/board/" + boardId))
+		.andExpect(status().isFound())
+		.andExpect(content().string(contains("投稿の削除に失敗しました")));
+	}
+
+}

--- a/src/test/java/com/example/repository/post/PostMapperTest.java
+++ b/src/test/java/com/example/repository/post/PostMapperTest.java
@@ -14,6 +14,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
 
 import com.example.domain.post.Post;
 import com.example.domain.user.User;
@@ -22,11 +23,12 @@ import lombok.extern.slf4j.Slf4j;
 
 @SpringBootTest
 @Slf4j
+@Transactional
 class PostMapperTest {
-	
+
 	@Autowired
 	PostMapper mapper;
-	
+
 	Post post1 = new Post();
 	Post post2 = new Post();
 	Post post3 = new Post();
@@ -43,7 +45,7 @@ class PostMapperTest {
 
 	@BeforeEach
 	void setUp() throws Exception {
-		
+
 		LocalDateTime insertDateTime4 = LocalDateTime.parse("2022-04-09T19:34:50.63");
 		LocalDateTime insertDateTime5 = LocalDateTime.parse("2022-05-09T19:34:50.63");
 		LocalDateTime insertDateTime6 = LocalDateTime.parse("2022-06-09T19:34:50.63");
@@ -53,29 +55,29 @@ class PostMapperTest {
 		user.setId(1L);
 		user.setMailAddress("aaa@aaa");
 		user.setPassword("test1");
-		
+
 		post1.setId(4L);
 		post1.setContents("ボーナスやった！！(4)");
 		post1.setInsertAt(insertDateTime4);
 		post1.setUpdateAt(updateDateTime4);
 		post1.setUser(user);
-		
+
 		post2.setId(5L);
 		post2.setContents("ボーナスやった！！(5)");
 		post2.setInsertAt(insertDateTime5);
 		post2.setUpdateAt(updateDateTime5);
 		post2.setUser(user);
-		
+
 		post3.setId(6L);
 		post3.setContents("ボーナスやった！！(6)");
 		post3.setInsertAt(insertDateTime6);
 		post3.setUpdateAt(updateDateTime6);
 		post3.setUser(user);
-		
+
 		expectedPostLists.add(post1);
 		expectedPostLists.add(post2);
 		expectedPostLists.add(post3);
-		
+
 	}
 
 	@AfterEach
@@ -85,47 +87,68 @@ class PostMapperTest {
 	@Test
 	@DisplayName("期待する投稿一覧のリストが返されているか")
 	void testFindPostList() {
-		
+
 		List<Post> mapperPostList = mapper.findPostList(3L);
-		
+
 		//期待する投稿一覧リストの0,1番目から投稿IDを抽出する
 		Long expectedPostId0 = expectedPostLists.get(0).getId();
 		Long expectedPostId1 = expectedPostLists.get(1).getId();
-		
+
 		//mapperから返された投稿一覧リストの0,1番目から投稿IDを抽出する
 		Long mapperPostId0 = mapperPostList.get(2).getId();
 		Long mapperPostId1 = mapperPostList.get(1).getId();
-				
+
 		//Listのsizeを比較する
 		assertEquals(3, mapperPostList.size());
 		//投稿IDが一致するかどうか
 		assertEquals(expectedPostId0, mapperPostId0);
 		assertEquals(expectedPostId1, mapperPostId1);
-		
+
 	}
-	
+
 	@Test
 	@DisplayName("存在しない掲示板番号(bordId)を渡した時、sizeが0のリストが返ってくるか")
 	void testFindPostListSizeZero() {
-		
+
 		//存在しない掲示板番号(bordId)を引数に渡す
 		List<Post> mapperPostList = mapper.findPostList(100L);
-		
+
 		//size()が0になっている場合正常にテストが通る
-		assertEquals(0,mapperPostList.size());
-		
+		assertEquals(0, mapperPostList.size());
+
 	}
-	
+
 	@Test
 	@DisplayName("投稿一覧のリストが投稿日順に並んで返されているか")
 	void testFindPostListOrderByDate() {
-		
+
 		List<Post> mapperPostList = mapper.findPostList(3L);
-		
+
 		//期待する投稿とmapperから返された投稿一が同じものを比較する
-		assertEquals(post3.getId(),mapperPostList.get(0).getId());
-		assertEquals(post2.getId(),mapperPostList.get(1).getId());
-		assertEquals(post1.getId(),mapperPostList.get(2).getId());
+		assertEquals(post3.getId(), mapperPostList.get(0).getId());
+		assertEquals(post2.getId(), mapperPostList.get(1).getId());
+		assertEquals(post1.getId(), mapperPostList.get(2).getId());
 	}
 
+	@Test
+	@DisplayName("投稿の削除が成功したとき、戻り値としてTrueを返す")
+	void whenDeletePostIsSuccess_returnTrue() {
+		// 準備
+		boolean actual;
+		// 実行
+		try {
+			actual = mapper.deletePost(post1.getId());
+		} catch (Exception e) {
+			actual = false;
+		}
+		// 検証
+		assertTrue(actual);
+	}
+
+	@Test
+	@DisplayName("投稿の削除が失敗したとき、戻り値としてFalseを返す")
+	void whenDeletePostIsFailed_returnFalse() {
+		// 実行&検証
+		assertThrows(Exception.class, () -> mapper.deletePost(null));
+	}
 }

--- a/src/test/java/com/example/service/post/impl/PostServiceImplTest.java
+++ b/src/test/java/com/example/service/post/impl/PostServiceImplTest.java
@@ -1,8 +1,8 @@
 package com.example.service.post.impl;
 
 import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.ArgumentMatchers.anyLong;
-import static org.mockito.Mockito.doReturn;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
 
 import java.time.LocalDateTime;
 import java.util.ArrayList;
@@ -24,19 +24,19 @@ import com.example.repository.post.PostMapper;
 
 @SpringBootTest
 class PostServiceImplTest {
-	
+
 	@InjectMocks
 	private PostServiceImpl serviceImpl;
-	
+
 	@Mock
 	private PostMapper mapper;
-	
+
 	Post post1 = new Post();
 	Post post2 = new Post();
 	Post post3 = new Post();
 	List<Post> postLists = new ArrayList<Post>();
 	User user = new User();
-	
+
 	@BeforeAll
 	static void setUpBeforeClass() throws Exception {
 	}
@@ -54,29 +54,29 @@ class PostServiceImplTest {
 		user.setId(1L);
 		user.setMailAddress("aaa@aaa");
 		user.setPassword("test1");
-		
+
 		post1.setId(4L);
 		post1.setContents("ボーナスやった！！(4)");
 		post1.setInsertAt(insertDateTime4);
 		post1.setUpdateAt(updateDateTime);
 		post1.setUser(user);
-		
+
 		post2.setId(5L);
 		post2.setContents("ボーナスやった！！(5)");
 		post2.setInsertAt(insertDateTime5);
 		post2.setUpdateAt(updateDateTime);
 		post2.setUser(user);
-		
+
 		post3.setId(6L);
 		post3.setContents("ボーナスやった！！(6)");
 		post3.setInsertAt(insertDateTime6);
 		post3.setUpdateAt(updateDateTime);
 		post3.setUser(user);
-		
+
 		postLists.add(post1);
 		postLists.add(post2);
 		postLists.add(post3);
-		
+
 	}
 
 	@AfterEach
@@ -94,6 +94,28 @@ class PostServiceImplTest {
 		List<Post> servicePostLists = serviceImpl.selectPostList(3L);
 		
 		assertEquals(postLists, servicePostLists);
+	}
+
+	@Test
+	@DisplayName("投稿の削除に成功したとき、戻り値としてTrueを返す")
+	void whenDeletePostIsSuccess_returnTrue() throws Exception {
+		// 準備
+		when(mapper.deletePost(1L)).thenReturn(true);
+		// 実行
+		boolean actual = serviceImpl.deletePost(1L);
+		// 検証
+		assertTrue(actual);
+	}
+
+	@Test
+	@DisplayName("投稿の削除に失敗したとき、戻り値としてFalseを返す")
+	void whenDeletePostIsFailed_returnFalse() throws Exception {
+		// 準備
+		when(mapper.deletePost(1L)).thenThrow(Exception.class);
+		// 実行
+		boolean actual = serviceImpl.deletePost(1L);
+		// 検証
+		assertFalse(actual);
 	}
 
 }


### PR DESCRIPTION
### MyBatisのテスト 2つ (133行以降をご確認ください)
* 投稿削除(成功)Trueを返す
* 投稿削除(失敗)例外を返す
→今回例外が出る原因として「投稿対象が存在しない」ということが考えられると思いました。

### Serviceのテスト 2つ
* 投稿削除(成功)trueを返す
* 投稿削除(失敗)falseを返す

### Controllerのテスト 2つ
* 前提条件(ユーザーはログイン済み、ユーザー情報と掲示板情報は定数で固定、削除用フォームクラスは作らない)
* 投稿削除(成功)、成功メッセージの表示
* 投稿削除(失敗)、失敗メッセージの表示
→ フォームがないのでバリデーションはなし、リダイレクト先は同じなので「メッセージ」で成功と失敗を判断
### 確認して欲しい内容
実装がまだないので、テストは全て通りません。
実装が完了後、テストの実施および修正を行いますので、現時点で気になることがあればご指摘お願いします。