### PR TITLE
CSV出力機能実装

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -89,6 +89,11 @@
 			<groupId>nz.net.ultraq.thymeleaf</groupId>
 			<artifactId>thymeleaf-layout-dialect</artifactId>
 		</dependency>
+		<dependency>
+			<groupId>net.sf.supercsv</groupId>
+			<artifactId>super-csv</artifactId>
+			<version>2.4.0</version>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/src/main/java/com/example/controller/kakeibo/KakeiboController.java
+++ b/src/main/java/com/example/controller/kakeibo/KakeiboController.java
@@ -5,6 +5,7 @@ import java.time.format.DateTimeFormatter;
 import java.util.List;
 import java.util.Map;
 
+import javax.servlet.http.HttpServletResponse;
 import javax.servlet.http.HttpSession;
 
 import org.springframework.beans.BeanUtils;
@@ -279,7 +280,7 @@ public class KakeiboController {
 		}
 
 		// リストが返ってきた時、kakeiboListに格納
-		model.addAttribute("kakeiboList",
+		session.setAttribute("kakeiboList",
 				kakeiboService.findKakeiboByYearAndMonth(searchKakeiboForm.getYear(), searchKakeiboForm.getMonth()));
 		// リストがnullの時、messageに格納
 		model.addAttribute("message", "ご入力頂いた年月のデータは存在しません（年の指定は必須です）");
@@ -288,5 +289,14 @@ public class KakeiboController {
 				kakeiboService.monthlyBalanceCalculate(searchKakeiboForm.getYear(), searchKakeiboForm.getMonth()));
 
 		return "kakeibo/kakeiboByYearAndMonth";
+	}
+	
+	/*
+	 * 年月を指定してCSV出力する
+	 */
+	@GetMapping("/csvKakeiboList")
+	public void getCsvKakeiboList(HttpServletResponse response) throws Exception {
+		
+		kakeiboService.csvDownloadKakeiboList(response);
 	}
 }

--- a/src/main/java/com/example/domain/kakeibo/CsvKakeibo.java
+++ b/src/main/java/com/example/domain/kakeibo/CsvKakeibo.java
@@ -1,0 +1,28 @@
+package com.example.domain.kakeibo;
+
+import java.sql.Timestamp;
+import java.time.LocalDate;
+
+import lombok.Data;
+
+@Data
+public class CsvKakeibo {
+
+	/** 決済日付 */
+	private LocalDate paymentDate;
+	/** 費目名 */
+	private String expenseItemName;
+	/** 支出金額 */
+	private Integer expenditureAmount;
+	/** 収入金額 */
+	private Integer incomeAmount;
+	/** 決済方法 */
+	private String settlementName;
+	/** 利用店舗 */
+	private String usedStore;
+	/** 備考 */
+	private String remarks;
+	/** 登録日 */
+	private Timestamp insertAt;
+
+}

--- a/src/main/resources/templates/kakeibo/kakeiboByYearAndMonth.html
+++ b/src/main/resources/templates/kakeibo/kakeiboByYearAndMonth.html
@@ -48,7 +48,7 @@
             </form>
 
             <!-- データが存在しない場合のメッセージ -->
-            <div th:unless="${kakeiboList}" th:text="${message}" style="color: red;"></div>
+            <div th:unless="${session.kakeiboList}" th:text="${message}" style="color: red;"></div>
 
             <!-- 収支計算ボックス -->
             <div th:if="${result}">
@@ -83,7 +83,7 @@
             </div>
     
             <!-- テーブル表示 -->
-            <div th:if="${kakeiboList}">
+            <div th:if="${session.kakeiboList}">
                 <div class="d-flex justify-content-between flex-wrap flex-md-nowrap align-items-center pt-3 pb-2 mb-3 border-bottom">
                     <div class="table-responsive">
                         <table class="table table-striped table-sm">
@@ -102,7 +102,7 @@
                                 </tr>
                             </thead>
                             <tbody>
-                                <tr th:each="kakeibo : ${kakeiboList}" class="align-middle">
+                                <tr th:each="kakeibo : ${session.kakeiboList}" class="align-middle">
                                     <td th:text="${kakeibo.paymentDate}">2022-09-01</td>
                                     <td th:text="${kakeibo.expenseItem.expenseItemName}">3</td>
                                     <td th:if="${kakeibo.expenditureAmount >= 1000}" th:text="${#numbers.formatInteger(kakeibo.expenditureAmount, 3, 'COMMA')} + '円'">3000</td>
@@ -129,6 +129,9 @@
                             </tbody>
                         </table>
                     </div>
+                </div>
+                <div class="btn-area">
+                    <a th:href="@{/kakeibo/csvKakeiboList}" class="btn btn-sm btn-outline-secondary">CSV出力</a>
                 </div>
             </div>
         </main>


### PR DESCRIPTION
# 追加機能

## CSV出力機能(年月で指定した際に出力できるように実装)
・出力項目は表示する項目と同じ内容

## 共有事項
・Kakeiboドメインから費目名や決済方法を取得することはできたのですが、
　オブジェクトのままCSVに表示されてしまっていたので、新たにCSV出力用のドメインを作成しております。
・modelでは検索後の値を保持できなかったので、「KakeiboList」をsessionで保持しています。

# 確認していただきたい点
・出力項目に不備はないか
・新しくドメインを作成せずに実装する方法をご存知の方がいたら共有して欲しいです！

## 確認用スクショ
<img width="1232" alt="スクリーンショット 2022-12-27 12 32 22" src="https://user-images.githubusercontent.com/105258005/209610768-e5088c02-5b0f-4080-863e-ebe55816d277.png">
<img width="825" alt="スクリーンショット 2022-12-27 12 32 40" src="https://user-images.githubusercontent.com/105258005/209610791-e716c8e9-9831-4929-a44e-36adadc11b96.png">


